### PR TITLE
ADDomain: Fix DNS Delegation issue

### DIFF
--- a/source/DSCResources/MSFT_ADDomain/MSFT_ADDomain.psm1
+++ b/source/DSCResources/MSFT_ADDomain/MSFT_ADDomain.psm1
@@ -487,6 +487,7 @@ function Set-TargetResource
         {
             $installADDSParameters['DnsDelegationCredential'] = $DnsDelegationCredential
             $installADDSParameters['CreateDnsDelegation'] = $true
+            $installADDSParameters['InstallDns'] = $true
         }
 
         if ($PSBoundParameters.ContainsKey('DatabasePath'))
@@ -523,6 +524,8 @@ function Set-TargetResource
             }
 
             Install-ADDSDomain @installADDSParameters
+            
+            Start-Service -Name "netlogon"
 
             Write-Verbose -Message ($script:localizedData.CreatedChildDomain)
         }
@@ -542,6 +545,8 @@ function Set-TargetResource
             }
 
             Install-ADDSForest @installADDSParameters
+            
+            Start-Service -Name "netlogon"
 
             Write-Verbose -Message ($script:localizedData.CreatedForest -f $DomainName)
         }


### PR DESCRIPTION
Added fix for issue #176 , DNS Delegation not included in ADDomain. And incorporated fix from https://github.com/ansible/ansible/issues/39235

#### Pull Request (PR) description
Added fix for above issues by:
- Adding InstallDNS switch if the `DnsDelegationCredential` option has been used
- Starting the `netlogon` service after domain installation

#### This Pull Request (PR) fixes the following issues
Fixes issue #176 ADDomain: DNS Delegation is no longer working.

#### Task list
- [ ] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
